### PR TITLE
Rename model properties

### DIFF
--- a/src/HttpClientHelpers.Test/HttpClientHelpers.Test.csproj
+++ b/src/HttpClientHelpers.Test/HttpClientHelpers.Test.csproj
@@ -64,6 +64,9 @@
       <Name>HttpClientHelpers</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Models/Models.csproj
+++ b/src/Models/Models.csproj
@@ -34,6 +34,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -47,6 +50,9 @@
     <Compile Include="Repo.cs" />
     <Compile Include="User.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Models/Repo.cs
+++ b/src/Models/Repo.cs
@@ -1,8 +1,12 @@
-﻿namespace Models
+﻿using Newtonsoft.Json;
+
+namespace Models
 {
     public class Repo
     {
         public string Name { get; set; }
-        public int StarGazers_Count { get; set; }
+
+        [JsonProperty("StarGazers_Count")]
+        public int Stars { get; set; }
     }
 }

--- a/src/Models/User.cs
+++ b/src/Models/User.cs
@@ -6,9 +6,9 @@ namespace Models
     {
         public string Name { get; set; }
         public string Location { get; set; }
-
         [JsonProperty("Avatar_url")]
         public string AvatarUrl { get; set; }
-        public string Repos_Url { get; set; }
+        [JsonProperty("Repos_Url")]
+        public string ReposUrl { get; set; }
     }
 }

--- a/src/Models/User.cs
+++ b/src/Models/User.cs
@@ -1,10 +1,14 @@
-﻿namespace Models
+﻿using Newtonsoft.Json;
+
+namespace Models
 {
     public class User
     {
         public string Name { get; set; }
         public string Location { get; set; }
-        public string Avatar_url { get; set; }
+
+        [JsonProperty("Avatar_url")]
+        public string AvatarUrl { get; set; }
         public string Repos_Url { get; set; }
     }
 }

--- a/src/Models/packages.config
+++ b/src/Models/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net46" />
+</packages>

--- a/src/Repositories.Test/Repositories.Test.csproj
+++ b/src/Repositories.Test/Repositories.Test.csproj
@@ -81,6 +81,9 @@
       <Name>Repositories</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/WebApp.Test/UsersControllerTests.cs
+++ b/src/WebApp.Test/UsersControllerTests.cs
@@ -46,7 +46,7 @@ namespace WebApp.Test
             var user = Builder<User>.CreateNew().Build();
 
             _mockRepository.Setup(x => x.GetDetailsForUser(Username)).Returns(user);
-            _mockRepository.Setup(x => x.GetReposForUserFromUrl(user.Repos_Url)).Returns(new List<Repo>());
+            _mockRepository.Setup(x => x.GetReposForUserFromUrl(user.ReposUrl)).Returns(new List<Repo>());
 
             //Act
             var result = _usersController.Index(Username) as ViewResult;

--- a/src/WebApp.Test/UsersControllerTests.cs
+++ b/src/WebApp.Test/UsersControllerTests.cs
@@ -73,7 +73,7 @@ namespace WebApp.Test
             //Assert
             var userViewModel = result.Model as UserViewModel;
             userViewModel.Repos.Should().HaveCount(5);
-            userViewModel.Repos.Should().BeInDescendingOrder(x => x.StarGazers_Count);
+            userViewModel.Repos.Should().BeInDescendingOrder(x => x.Stars);
         }
     }
 }

--- a/src/WebApp.Test/UsersControllerTests.cs
+++ b/src/WebApp.Test/UsersControllerTests.cs
@@ -55,7 +55,7 @@ namespace WebApp.Test
             var userViewModel = result.Model as UserViewModel;
             userViewModel.Name.Should().Be(user.Name);
             userViewModel.Location.Should().Be(user.Location);
-            userViewModel.AvatarUrl.Should().Be(user.Avatar_url);
+            userViewModel.AvatarUrl.Should().Be(user.AvatarUrl);
         }
 
         [Test]

--- a/src/WebApp.Test/WebApp.Test.csproj
+++ b/src/WebApp.Test/WebApp.Test.csproj
@@ -106,6 +106,9 @@
       <Name>WebApp</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/WebApp/Controllers/UsersController.cs
+++ b/src/WebApp/Controllers/UsersController.cs
@@ -32,7 +32,7 @@ namespace WebApp.Controllers
                 Name = user.Name,
                 Location = user.Location,
                 AvatarUrl = user.Avatar_url,
-                Repos = repos.OrderByDescending(x => x.StarGazers_Count).Take(5).ToList()
+                Repos = repos.OrderByDescending(x => x.Stars).Take(5).ToList()
             };
 
             return View(model);

--- a/src/WebApp/Controllers/UsersController.cs
+++ b/src/WebApp/Controllers/UsersController.cs
@@ -25,7 +25,7 @@ namespace WebApp.Controllers
                 return RedirectToAction("NoResultsFound", new { message = $"{username} does not exists"});
             }
 
-            var repos = _repository.GetReposForUserFromUrl(user.Repos_Url);
+            var repos = _repository.GetReposForUserFromUrl(user.ReposUrl);
 
             var model = new UserViewModel
             {

--- a/src/WebApp/Controllers/UsersController.cs
+++ b/src/WebApp/Controllers/UsersController.cs
@@ -31,7 +31,7 @@ namespace WebApp.Controllers
             {
                 Name = user.Name,
                 Location = user.Location,
-                AvatarUrl = user.Avatar_url,
+                AvatarUrl = user.AvatarUrl,
                 Repos = repos.OrderByDescending(x => x.Stars).Take(5).ToList()
             };
 

--- a/src/WebApp/Views/Users/Index.cshtml
+++ b/src/WebApp/Views/Users/Index.cshtml
@@ -24,7 +24,7 @@
             {
                 <tr>
                     <td>@repo.Name</td>
-                    <td>@repo.StarGazers_Count</td>
+                    <td>@repo.Stars</td>
                 </tr>
             }
         }


### PR DESCRIPTION
The names for some model properties are not suitable and are the json property name.

- [x] Rename properties
- [x] Specify JsonProperty to ensure serialization of json to model property
- [x] Ensure tests pass
- [x] Ensure application functionality remains